### PR TITLE
fix: sentry FARI-11

### DIFF
--- a/lib/routes/Play/PlayRoute.tsx
+++ b/lib/routes/Play/PlayRoute.tsx
@@ -25,7 +25,7 @@ export const PlayRoute: React.FC<{
   });
   const connectionsManager = usePeerConnection({
     onHostDataReceive(newScene) {
-      sceneManager.actions.setScene(newScene);
+      sceneManager.actions.safeSetScene(newScene);
     },
     debug: debug,
   });

--- a/lib/routes/Play/useScene/useScene.ts
+++ b/lib/routes/Play/useScene/useScene.ts
@@ -24,6 +24,12 @@ export function useScene(userId: string, gameId: string) {
     players: [],
   }));
 
+  function safeSetScene(scene: IScene) {
+    if (scene) {
+      setScene(scene);
+    }
+  }
+
   function reset() {
     setScene(
       produce((draft: IScene) => {
@@ -273,7 +279,7 @@ export function useScene(userId: string, gameId: string) {
     state: { scene },
     actions: {
       reset,
-      setScene,
+      safeSetScene,
       setName,
       addAspect,
       addBoost,


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: Sentry issue FARI-11

## 🌄 Context

<!-- Provide more context around why this pull requests was created -->

It seems like when a player loses connection to the host, it certain cases the host might send an "empty scene" which crashes the rendering cycle.

This PR makes sure that it's not possible to set a scene has `undefined`

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->

![image](https://user-images.githubusercontent.com/6224111/82134068-6eb41780-97c1-11ea-9b34-3b55c2a1737e.png)
