### PR TITLE
fix: getting random die side now is truly fair based on the number of side

### DIFF
--- a/lib/domains/dice/Dice.ts
+++ b/lib/domains/dice/Dice.ts
@@ -22,8 +22,6 @@ function rollDie(die: Array<number>, times: number): IDiceRoll {
   return { total, rolls };
 }
 
-function getRandomDieSide(numberOfSides: number) {
-  const randomNumber = Math.round(Math.random() * 100);
-  const side = randomNumber % numberOfSides;
-  return side;
+function getRandomDieSide(numberOfSides: number): number {
+  return Math.trunc(Math.random() * numberOfSides);
 }


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- **Fix**: Die rolls are now truly fair, and no longer slightly biased downwards.

## 🌄 Context

This should resolve #56

<!-- Provide more context around why this pull requests was created -->

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
