### PR TITLE
feat: drawing component on scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains the source code that powers Fari.
 
 If you are here because
 
-1. you have an encountered issue with Fari
+1. you have encountered issue with Fari
 2. you want to ask a question
 3. you have a feature suggestion
 

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -1,0 +1,186 @@
+import { Fade, useTheme } from "@material-ui/core";
+import GestureIcon from "@material-ui/icons/Gesture";
+import { css } from "emotion";
+import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
+import { useTextColors } from "../../hooks/useTextColors/useTextColors";
+
+export type ILines = Array<ILine>;
+
+interface IProps {
+  lines?: ILines;
+  readonly?: boolean;
+  onChange?(lines: ILines): void;
+}
+
+interface IHandles {
+  clear(): void;
+}
+
+export type IDrawAreaHandles = IHandles;
+
+export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
+  const theme = useTheme();
+  const textColors = useTextColors(theme.palette.background.paper);
+
+  const [lines, setLines] = useState<ILines>([]);
+  const [isDrawing, setDrawing] = useState(false);
+  const $container = useRef<HTMLDivElement>(undefined);
+
+  useEffect(() => {
+    if (props.lines && props.readonly) {
+      setLines(props.lines);
+    }
+  }, [props.lines, props.readonly]);
+
+  useImperativeHandle(ref, () => {
+    return {
+      clear() {
+        setLines([]);
+      },
+    };
+  });
+
+  useEffect(() => {
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isDrawing) {
+      props.onChange?.(lines);
+    }
+  }, [isDrawing]);
+
+  function handleMouseDown(
+    mouseEvent: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) {
+    if (mouseEvent.button !== 0) {
+      return;
+    }
+
+    const newPoint = relativeCoordinatesForEvent(mouseEvent);
+    setLines((lines) => {
+      return [...lines, [newPoint]];
+    });
+    setDrawing(true);
+  }
+
+  function handleMouseMove(
+    mouseEvent: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) {
+    if (!isDrawing) {
+      return;
+    }
+
+    const newPoint = relativeCoordinatesForEvent(mouseEvent);
+    setLines((lines) => {
+      const lastLineIndex = lines.length - 1;
+      return lines.map((line, index) => {
+        if (index !== lastLineIndex) {
+          return line;
+        }
+        const updatedLine = [...line, newPoint];
+        return updatedLine;
+      });
+    });
+  }
+
+  function handleDoubleClick() {
+    setLines([]);
+  }
+
+  function handleMouseUp() {
+    setDrawing(false);
+  }
+
+  function relativeCoordinatesForEvent(
+    mouseEvent: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ): IPoint {
+    const boundingRect = $container.current.getBoundingClientRect();
+    const x = mouseEvent.clientX - boundingRect.left;
+    const y = mouseEvent.clientY - boundingRect.top;
+    const point = {
+      x: x,
+      y: y,
+      percentX: (x / boundingRect.width) * 100,
+      percentY: (y / boundingRect.height) * 100,
+    } as IPoint;
+    return point;
+  }
+
+  return (
+    <div
+      className={css({
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        width: "100%",
+        height: "100%",
+        cursor: "crosshair",
+      })}
+      ref={$container}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onDoubleClick={handleDoubleClick}
+    >
+      {lines.length === 0 ? (
+        <Fade in>
+          <GestureIcon
+            classes={{
+              root: css({
+                width: "7rem",
+                height: "7rem",
+              }),
+            }}
+            htmlColor={textColors.disabled}
+          ></GestureIcon>
+        </Fade>
+      ) : (
+        <svg
+          width="100%"
+          height="100%"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className={css({
+            "& path": {
+              fill: "none",
+              strokeWidth: "3.5px",
+              stroke: textColors.secondary,
+              strokeLinejoin: "round",
+              strokeLinecap: "round",
+            },
+          })}
+        >
+          {lines.map((line, index) => (
+            <DrawingLine key={index} line={line} />
+          ))}
+        </svg>
+      )}
+    </div>
+  );
+});
+
+DrawArea.displayName = "DrawArea";
+
+export const DrawingLine: React.FC<{ line: ILine }> = (props) => {
+  const pathData = `M ${props.line
+    .map((p) => {
+      return `${p.percentX} ${p.percentY}`;
+    })
+    .join(" L ")}`;
+  return <path d={pathData} vectorEffect="non-scaling-stroke" />;
+};
+
+DrawingLine.displayName = "DrawingLine";
+
+type ILine = Array<IPoint>;
+
+type IPoint = {
+  x: number;
+  y: number;
+  percentX: number;
+  percentY: number;
+};

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -148,7 +148,7 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
             className={css({
               "& path": {
                 fill: "none",
-                strokeWidth: "3.5px",
+                strokeWidth: "5px",
                 stroke: textColors.secondary,
                 strokeLinejoin: "round",
                 strokeLinecap: "round",
@@ -168,11 +168,12 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
 DrawArea.displayName = "DrawArea";
 
 export const DrawingLine: React.FC<{ line: ILine }> = (props) => {
-  const pathData = `M ${props.line
+  const lineData = props.line
     .map((p) => {
       return `${p.percentX} ${p.percentY}`;
     })
-    .join(" L ")}`;
+    .join(" L ");
+  const pathData = `M ${lineData}`;
   return <path d={pathData} vectorEffect="non-scaling-stroke" />;
 };
 

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -139,25 +139,27 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
           ></GestureIcon>
         </Fade>
       ) : (
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          className={css({
-            "& path": {
-              fill: "none",
-              strokeWidth: "3.5px",
-              stroke: textColors.secondary,
-              strokeLinejoin: "round",
-              strokeLinecap: "round",
-            },
-          })}
-        >
-          {lines.map((line, index) => (
-            <DrawingLine key={index} line={line} />
-          ))}
-        </svg>
+        <Fade in>
+          <svg
+            width="100%"
+            height="100%"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className={css({
+              "& path": {
+                fill: "none",
+                strokeWidth: "3.5px",
+                stroke: textColors.secondary,
+                strokeLinejoin: "round",
+                strokeLinecap: "round",
+              },
+            })}
+          >
+            {lines.map((line, index) => (
+              <DrawingLine key={index} line={line} />
+            ))}
+          </svg>
+        </Fade>
       )}
     </div>
   );

--- a/lib/components/Page/Page.tsx
+++ b/lib/components/Page/Page.tsx
@@ -17,6 +17,7 @@ import {
 import Brightness4Icon from "@material-ui/icons/Brightness4";
 import Brightness7Icon from "@material-ui/icons/Brightness7";
 import GitHubIcon from "@material-ui/icons/GitHub";
+import LocalCafeIcon from "@material-ui/icons/LocalCafe";
 import MenuIcon from "@material-ui/icons/Menu";
 import { css } from "emotion";
 import React, { useContext, useEffect, useState } from "react";
@@ -308,6 +309,7 @@ export const Page: React.FC<{
             }}
             variant={mobile ? "outlined" : undefined}
             fullWidth={mobile}
+            endIcon={<LocalCafeIcon></LocalCafeIcon>}
           >
             {t("menu.support")}
           </Button>

--- a/lib/components/Page/Page.tsx
+++ b/lib/components/Page/Page.tsx
@@ -17,7 +17,6 @@ import {
 import Brightness4Icon from "@material-ui/icons/Brightness4";
 import Brightness7Icon from "@material-ui/icons/Brightness7";
 import GitHubIcon from "@material-ui/icons/GitHub";
-import LocalCafeIcon from "@material-ui/icons/LocalCafe";
 import MenuIcon from "@material-ui/icons/Menu";
 import { css } from "emotion";
 import React, { useContext, useEffect, useState } from "react";
@@ -309,7 +308,6 @@ export const Page: React.FC<{
             }}
             variant={mobile ? "outlined" : undefined}
             fullWidth={mobile}
-            endIcon={<LocalCafeIcon></LocalCafeIcon>}
           >
             {t("menu.support")}
           </Button>

--- a/lib/routes/Play/PlayPage.tsx
+++ b/lib/routes/Play/PlayPage.tsx
@@ -1,9 +1,37 @@
-import { Box, Button, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Fade, Grid, Hidden, InputLabel, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, ThemeProvider, Tooltip, Typography, useMediaQuery, useTheme } from "@material-ui/core";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Fade,
+  Grid,
+  Hidden,
+  InputLabel,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  ThemeProvider,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@material-ui/core";
 import BugReportIcon from "@material-ui/icons/BugReport";
 import EmojiPeopleIcon from "@material-ui/icons/EmojiPeople";
 import ErrorIcon from "@material-ui/icons/Error";
 import FaceIcon from "@material-ui/icons/Face";
 import FileCopyIcon from "@material-ui/icons/FileCopy";
+import GestureIcon from "@material-ui/icons/Gesture";
 import LoupeIcon from "@material-ui/icons/Loupe";
 import NoteIcon from "@material-ui/icons/Note";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
@@ -14,6 +42,7 @@ import { css, cx } from "emotion";
 import React, { useEffect, useRef, useState } from "react";
 import { Prompt } from "react-router";
 import { ContentEditable } from "../../components/ContentEditable/ContentEditable";
+import { DrawArea, IDrawAreaHandles } from "../../components/DrawArea/DrawArea";
 import { IndexCard } from "../../components/IndexCard/IndexCard";
 import { IndexCardColorTypes } from "../../components/IndexCard/IndexCardColor";
 import { MagicGridContainer } from "../../components/MagicGridContainer/MagicGridContainer";
@@ -56,6 +85,8 @@ export const PlayPage: React.FC<IProps> = (props) => {
   const [offlineCharacterDialogOpen, setOfflineCharacterDialogOpen] = useState(
     false
   );
+  const $drawArea = useRef<IDrawAreaHandles>(undefined);
+
   const [offlineCharacterName, setOfflineCharacterName] = useState("");
   useEffect(() => {
     if (shareLinkToolTip.open) {
@@ -78,6 +109,7 @@ export const PlayPage: React.FC<IProps> = (props) => {
   const shouldRenderPlayerJoinGameScreen =
     !isGM && !connectionsManager.state.isConnectedToHost;
 
+  const paperStyle = css({ borderRadius: "0px" });
   return (
     <Page gameId={props.idFromParams}>
       <Prompt when={isGM || isOffline} message={t("play-route.leave-prompt")} />
@@ -279,8 +311,8 @@ export const PlayPage: React.FC<IProps> = (props) => {
           </Grid>
         </Box>
 
-        <Paper>
-          <TableContainer component={Paper}>
+        <Paper className={paperStyle}>
+          <TableContainer>
             <Table
               size="small"
               className={css({
@@ -345,6 +377,33 @@ export const PlayPage: React.FC<IProps> = (props) => {
               </TableBody>
             </Table>
           </TableContainer>
+        </Paper>
+        <Paper className={paperStyle}>
+          <Divider light></Divider>
+          <Box width="100%" height="400px">
+            <DrawArea
+              ref={$drawArea}
+              lines={sceneManager.state.scene.drawAreaLines}
+              readonly={!isGM}
+              onChange={(lines) => {
+                sceneManager.actions.setDrawAreaLines(lines);
+              }}
+            ></DrawArea>
+          </Box>
+          <Divider></Divider>
+          <Box p="1rem" display="flex" justifyContent="flex-end">
+            <Button
+              onClick={() => {
+                if ($drawArea.current) {
+                  $drawArea.current.clear();
+                  sceneManager.actions.setDrawAreaLines([]);
+                }
+              }}
+              endIcon={<GestureIcon></GestureIcon>}
+            >
+              {"Clear"}
+            </Button>
+          </Box>
         </Paper>
       </Box>
     );

--- a/lib/routes/Play/useScene/IScene.ts
+++ b/lib/routes/Play/useScene/IScene.ts
@@ -1,3 +1,4 @@
+import { ILines } from "../../../components/DrawArea/DrawArea";
 import { IndexCardColorTypes } from "../../../components/IndexCard/IndexCardColor";
 import { IDiceRoll } from "../../../domains/dice/IDiceRoll";
 import { AspectType } from "./AspectType";
@@ -30,4 +31,5 @@ export interface IScene {
   goodConfetti: number;
   badConfetti: number;
   sort: boolean;
+  drawAreaLines: ILines;
 }

--- a/lib/routes/Play/useScene/useScene.ts
+++ b/lib/routes/Play/useScene/useScene.ts
@@ -2,6 +2,7 @@ import produce from "immer";
 import Peer from "peerjs";
 import { useEffect, useState } from "react";
 import { v4 as uuidV4 } from "uuid";
+import { ILines } from "../../../components/DrawArea/DrawArea";
 import { IndexCardColorTypes } from "../../../components/IndexCard/IndexCardColor";
 import { Confetti } from "../../../domains/confetti/Confetti";
 import { IDiceRoll } from "../../../domains/dice/IDiceRoll";
@@ -26,6 +27,7 @@ export function useScene(userId: string, gameId: string) {
     goodConfetti: 0,
     badConfetti: 0,
     sort: false,
+    drawAreaLines: [],
   }));
 
   useEffect(() => {
@@ -321,6 +323,14 @@ export function useScene(userId: string, gameId: string) {
     );
   }
 
+  function setDrawAreaLines(lines: ILines) {
+    setScene(
+      produce((draft: IScene) => {
+        draft.drawAreaLines = lines;
+      })
+    );
+  }
+
   return {
     state: { scene },
     actions: {
@@ -352,6 +362,7 @@ export function useScene(userId: string, gameId: string) {
       fireGoodConfetti,
       fireBadConfetti,
       toggleSort,
+      setDrawAreaLines,
     },
   };
 }

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -20,6 +20,12 @@ export const defaultThemeConfiguration: ThemeOptions = {
       root: {
         borderRadius: "20px",
       },
+      contained: {
+        fontWeight: 700,
+      },
+      outlined: {
+        fontWeight: 700,
+      },
     },
   },
 };


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- feat: new DrawArea component
- feat: used DrawArea in session
- feat: sync DrawArea using Peer to Peer
- style: bolder buttons

## 🌄 Context

This PRs adds a new Drawing Area on Scenes where GMs can draw zones or else. Anything the GM draws is synced to the players using peer to peer communication

Closes #58 

<!-- Provide more context around why this pull requests was created -->

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples
![image](https://user-images.githubusercontent.com/6224111/82763209-f3abbc00-9dd3-11ea-871c-84a73d91e173.png)

![image](https://user-images.githubusercontent.com/6224111/82763232-23f35a80-9dd4-11ea-9ad9-4f3b0dab0337.png)

![image](https://user-images.githubusercontent.com/6224111/82763235-29e93b80-9dd4-11ea-8bd8-8cd19a6fce7e.png)

<!-- Give examples or screenshots detailing the new behaviors of the application -->
