### PR TITLE
feat: import export scenes and characters

### DIFF
--- a/lib/components/CharactersManager/CharactersManager.tsx
+++ b/lib/components/CharactersManager/CharactersManager.tsx
@@ -1,10 +1,11 @@
 import { useTheme } from "@material-ui/core";
 import React, { useContext } from "react";
 import { useHistory } from "react-router";
+import { v4 as uuidV4 } from "uuid";
 import {
   CharactersContext,
   CharacterType,
-  ICharacter,
+  ICharacter
 } from "../../contexts/CharactersContext/CharactersContext";
 import { Manager } from "../Manager/Manager";
 
@@ -42,6 +43,33 @@ export const CharactersManager: React.FC<IProps> = (props) => {
     charactersManager.actions.remove(character.id);
   }
 
+  function onImport(charactersToImport: FileList | null) {
+    if (charactersToImport) {
+      var reader = new FileReader();
+      reader.onload = function (event) {
+        if (event.target) {
+          if (event.target.result) {
+            var importingChar = JSON.parse(event.target.result.toString()) as ICharacter;
+            importingChar.id = uuidV4();
+            charactersManager.actions.upsert(importingChar);
+          }
+        }
+
+      };
+      reader.readAsText(charactersToImport[0]);
+    }
+  }
+
+  function onExport(character: ICharacter) {
+    var characterDataAsString = JSON.stringify(character);
+    var characterDataAsBlob = new Blob([characterDataAsString], { type: "text/plain" });
+    var downloadURL = URL.createObjectURL(characterDataAsBlob);
+    var secretLink = document.createElement("a");
+    secretLink.href = downloadURL;
+    secretLink.download = character.name + "_data.json";
+    secretLink.click();
+  }
+
   return (
     <Manager
       list={charactersManager.state.characters}
@@ -56,6 +84,8 @@ export const CharactersManager: React.FC<IProps> = (props) => {
       onDelete={onDelete}
       onUndo={onUndo}
       onClose={charactersManager.actions.closeManager}
+      onImport={onImport}
+      onExport={onExport}
     />
   );
 };

--- a/lib/components/Manager/Manager.tsx
+++ b/lib/components/Manager/Manager.tsx
@@ -12,9 +12,10 @@ import {
   ListItemText,
   Snackbar,
   useMediaQuery,
-  useTheme,
+  useTheme
 } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/Delete";
+import ExportIcon from "@material-ui/icons/GetApp";
 import { Alert } from "@material-ui/lab";
 import { css } from "emotion";
 import React, { useState } from "react";
@@ -38,6 +39,8 @@ type IProps<T extends IBaseItem> = {
   onAdd(): void;
   onDelete(item: T): void;
   onUndo(item: T): void;
+  onImport(importPaths: FileList | null): void;
+  onExport(item: T): void;
 };
 
 export const Manager = <T extends IBaseItem>(props: IProps<T>) => {
@@ -67,6 +70,16 @@ export const Manager = <T extends IBaseItem>(props: IProps<T>) => {
     setDeletedObject(item);
     setDeletedSnack(true);
     props.onDelete(item);
+  }
+
+  function onImport(itemsToImport: FileList | null) {
+    if (itemsToImport) {
+      props.onImport(itemsToImport);
+    }
+  }
+
+  function onExport(item: T) {
+    props.onExport(item);
   }
 
   return (
@@ -117,6 +130,10 @@ export const Manager = <T extends IBaseItem>(props: IProps<T>) => {
           <Button color="primary" variant="outlined" onClick={onAdd}>
             {t("manager.new")}
           </Button>
+          <Button color="primary" variant="outlined" component="label">
+            {t("manager.import")}
+            <input type="file" accept=".json" style={{ display: "none" }} onChange={(event) => onImport(event.target.files)} />
+          </Button>
         </Grid>
       </Grid>
     );
@@ -154,6 +171,9 @@ export const Manager = <T extends IBaseItem>(props: IProps<T>) => {
               onClick={() => {
                 onItemClick(item);
               }}
+              className={css({
+                paddingRight: "102px"
+              })}
             >
               <ListItemAvatar>
                 <Avatar
@@ -171,6 +191,14 @@ export const Manager = <T extends IBaseItem>(props: IProps<T>) => {
               />
               {props.mode === ManagerMode.Manage && (
                 <ListItemSecondaryAction>
+                  <IconButton
+                    edge="start"
+                    onClick={() => {
+                      onExport(item);
+                    }}
+                  >
+                    <ExportIcon />
+                  </IconButton>
                   <IconButton
                     edge="end"
                     onClick={() => {

--- a/lib/components/Manager/domains/ListItem.ts
+++ b/lib/components/Manager/domains/ListItem.ts
@@ -7,9 +7,9 @@ export const listItem = {
       const options: Intl.DateTimeFormatOptions = {
         hour: "numeric",
         minute: "numeric",
-        weekday: "long",
+        weekday: "short",
         day: "numeric",
-        month: "long",
+        month: "short",
         year: "numeric",
       };
       const formattedDate = new Date(timestamp).toLocaleDateString(

--- a/lib/components/ScenesManager/ScenesManager.tsx
+++ b/lib/components/ScenesManager/ScenesManager.tsx
@@ -1,9 +1,10 @@
 import { useTheme } from "@material-ui/core";
 import React, { useContext } from "react";
 import { useHistory } from "react-router";
+import { v4 as uuidV4 } from "uuid";
 import {
   ISavableScene,
-  ScenesContext,
+  ScenesContext
 } from "../../contexts/SceneContext/ScenesContext";
 import { Manager } from "../Manager/Manager";
 
@@ -39,6 +40,32 @@ export const ScenesManager: React.FC<IProps> = (props) => {
     scenesManager.actions.remove(scene.id);
   }
 
+  function onImport(scenesToImport: FileList | null) {
+    if (scenesToImport) {
+      var reader = new FileReader();
+      reader.onload = function (event) {
+        if (event.target) {
+          if (event.target.result) {
+            var importingScene = JSON.parse(event.target.result.toString()) as ISavableScene;
+            importingScene.id = uuidV4();
+            scenesManager.actions.upsert(importingScene);
+          }
+        }
+      }
+      reader.readAsText(scenesToImport[0]);
+    }
+  }
+
+  function onExport(scene: ISavableScene) {
+    var sceneDataAsString = JSON.stringify(scene);
+    var sceneDataAsBlob = new Blob([sceneDataAsString], { type: "text/plain" });
+    var downloadURL = URL.createObjectURL(sceneDataAsBlob);
+    var secretLink = document.createElement("a");
+    secretLink.href = downloadURL;
+    secretLink.download = scene.name + "_data.json";
+    secretLink.click();
+  }
+
   return (
     <Manager
       list={scenesManager.state.scenes}
@@ -53,6 +80,8 @@ export const ScenesManager: React.FC<IProps> = (props) => {
       onDelete={onDelete}
       onUndo={onUndo}
       onClose={scenesManager.actions.closeManager}
+      onImport={onImport}
+      onExport={onExport}
     />
   );
 };

--- a/lib/services/internationalization/locales/enTranslation.ts
+++ b/lib/services/internationalization/locales/enTranslation.ts
@@ -69,6 +69,7 @@ export const enTranslation = {
   "index-card.remove": `Remove`,
   "index-card.reset": `Reset`,
   "manager.deleted": `Deleted`,
+  "manager.import": `Import`,
   "manager.leave-without-saving": `Are you sure you want to leave without saving ?`,
   "manager.new": `New`,
   "manager.no-items": `There's nothing here yet`,

--- a/lib/services/internationalization/locales/esTranslation.ts
+++ b/lib/services/internationalization/locales/esTranslation.ts
@@ -74,6 +74,7 @@ export const esTranslation: Record<
   "index-card.remove": `Quitar`,
   "index-card.reset": `Reiniciar`,
   "manager.deleted": undefined,
+  "manager.import": undefined,
   "manager.leave-without-saving": undefined,
   "manager.new": undefined,
   "manager.no-items": undefined,

--- a/lib/services/internationalization/locales/ptTranslation.ts
+++ b/lib/services/internationalization/locales/ptTranslation.ts
@@ -71,6 +71,7 @@ export const ptTranslation: Record<IPossibleTranslationKeys, any> = {
   "index-card.remove": undefined,
   "index-card.reset": undefined,
   "manager.deleted": undefined,
+  "manager.import": undefined,
   "manager.leave-without-saving": undefined,
   "manager.new": undefined,
   "manager.no-items": undefined,


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

-**feat** Can now export scenes to a json file, to allow sharing it to other devices/individuals. 
-**feat** Can now export characters to a json file, to allow sharing it to other devices/individuals.
-**feat** Can now import scenes from a json file
-**feat** Can now import characters from a json file

## 🌄 Context

<!-- Provide more context around why this pull request was created -->
Recently discovered this tool and so I'm planning on using it for an upcoming event. However I wanted an easier way to get my players all setup with their custom characters ahead of time. Saw the recent updates to allow for local saving, which got my thinking of an export/import feature for characters being possible. Once that was done, the scenes were an easy next step. 

## 🔒Checklist

- Made new character using existing features
- Exported character using new feature
- Made local edits to recently downloaded files
- Imported edited file
- Confirmed original and imported file exist as two different characters
- Repeat process for Scenes

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
