### PR TITLE
feat: touch support for DrawArea component

### DIFF
--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -27,7 +27,7 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   const [isDrawing, setDrawing] = useState(false);
   const $container = useRef<HTMLDivElement | null>(null);
 
-  const handleScrolling = useCallback(() => {
+  const handleScrolling = useCallback((event) => {
     event?.preventDefault();
 
   }, []);
@@ -194,6 +194,7 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   );
 });
 
+DrawArea.displayName = "DrawArea";
 
 export const DrawingLine: React.FC<{ line: ILine }> = (props) => {
   const lineData = props.line

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -26,11 +26,11 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   const [lines, setLines] = useState<ILines>([]);
   const [isDrawing, setDrawing] = useState(false);
   const $container = useRef<HTMLDivElement | null>(null);
-  const [scrollEnabled, setScrollEnabled] = useState(true);
+
   const handleScrolling = useCallback(() => {
     event?.preventDefault();
 
-  }, [setScrollEnabled]);
+  }, []);
 
   useEffect(() => {
     if (props.lines && props.readonly) {
@@ -58,10 +58,10 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   });
 
   useEffect(() => {
-    document.addEventListener("pointerup", handleMouseUp);
+    document.addEventListener("pointerup", handlePointerUp);
 
     return () => {
-      document.removeEventListener("pointerup", handleMouseUp);
+      document.removeEventListener("pointerup", handlePointerUp);
     };
   }, []);
 
@@ -80,15 +80,15 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
     }
   }, [isDrawing]);
 
-  function handleMouseDown(
-    mouseEvent: React.PointerEvent<HTMLDivElement>
+  function handlePointerDown(
+    pointerEvent: React.PointerEvent<HTMLDivElement>
   ) {
 
-    if (mouseEvent.button !== 0 || props.readonly) {
+    if (pointerEvent.button !== 0 || props.readonly) {
       return;
     }
 
-    const newPoint = relativeCoordinatesForEvent(mouseEvent);
+    const newPoint = relativeCoordinatesForEvent(pointerEvent);
     if (newPoint) {
       setLines((lines) => {
         return [...lines, [newPoint]];
@@ -97,14 +97,14 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
     }
   }
 
-  function handleMouseMove(
-    mouseEvent: React.PointerEvent<HTMLDivElement>
+  function handlePointerMove(
+    pointerEvent: React.PointerEvent<HTMLDivElement>
   ) {
     if (!isDrawing) {
       return;
     }
 
-    const newPoint = relativeCoordinatesForEvent(mouseEvent);
+    const newPoint = relativeCoordinatesForEvent(pointerEvent);
     if (newPoint) {
       setLines((lines) => {
         const lastLineIndex = lines.length - 1;
@@ -119,17 +119,17 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
     }
   }
 
-  function handleMouseUp() {
+  function handlePointerUp() {
     setDrawing(false);
   }
 
   function relativeCoordinatesForEvent(
-    mouseEvent: React.PointerEvent<HTMLDivElement>
+    pointerEvent: React.PointerEvent<HTMLDivElement>
   ): IPoint | undefined {
     if ($container.current) {
       const boundingRect = $container.current.getBoundingClientRect();
-      const x = mouseEvent.clientX - boundingRect.left;
-      const y = mouseEvent.clientY - boundingRect.top;
+      const x = pointerEvent.clientX - boundingRect.left;
+      const y = pointerEvent.clientY - boundingRect.top;
       const point = {
         x: x,
         y: y,
@@ -151,9 +151,9 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
         cursor: props.readonly ? "inherit" : "crosshair",
       })}
       ref={$container}
-      onPointerDown={handleMouseDown}
-      onPointerMove={handleMouseMove}
-      onPointerUp={handleMouseUp}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
     >
       {lines.length === 0 ? (
         <Fade in>
@@ -194,7 +194,6 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   );
 });
 
-DrawArea.displayName = "DrawArea";
 
 export const DrawingLine: React.FC<{ line: ILine }> = (props) => {
   const lineData = props.line

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -27,11 +27,6 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   const [isDrawing, setDrawing] = useState(false);
   const $container = useRef<HTMLDivElement | null>(null);
 
-  // const handleScrolling = useCallback((event) => {
-  //   event?.preventDefault();
-
-  // }, []);
-
   useEffect(() => {
     if (props.lines && props.readonly) {
       setLines(props.lines);
@@ -62,15 +57,6 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
       props.onChange?.(lines);
     }
   }, [isDrawing]);
-
-  // useEffect(() => {
-  //   if (isDrawing) {
-  //     window.addEventListener("touchstart", handleScrolling, { 'passive': false });
-  //   }
-  //   else {
-  //     window.removeEventListener("touchstart", handleScrolling);
-  //   }
-  // }, [isDrawing]);
 
   function handlePointerDown(
     pointerEvent: React.PointerEvent<HTMLDivElement>

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -76,7 +76,7 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
       window.addEventListener("touchstart", handleScrolling, { 'passive': false });
     }
     else {
-      window.removeEventListener("touchstart", handleScrolling, { 'passive': false });
+      window.removeEventListener("touchstart", handleScrolling);
     }
   }, [isDrawing]);
 

--- a/lib/components/DrawArea/DrawArea.tsx
+++ b/lib/components/DrawArea/DrawArea.tsx
@@ -1,7 +1,7 @@
 import { Fade, useTheme } from "@material-ui/core";
 import GestureIcon from "@material-ui/icons/Gesture";
 import { css } from "emotion";
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { useTextColors } from "../../hooks/useTextColors/useTextColors";
 
 export type ILines = Array<ILine>;
@@ -27,10 +27,10 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   const [isDrawing, setDrawing] = useState(false);
   const $container = useRef<HTMLDivElement | null>(null);
 
-  const handleScrolling = useCallback((event) => {
-    event?.preventDefault();
+  // const handleScrolling = useCallback((event) => {
+  //   event?.preventDefault();
 
-  }, []);
+  // }, []);
 
   useEffect(() => {
     if (props.lines && props.readonly) {
@@ -58,27 +58,19 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
   });
 
   useEffect(() => {
-    document.addEventListener("pointerup", handlePointerUp);
-
-    return () => {
-      document.removeEventListener("pointerup", handlePointerUp);
-    };
-  }, []);
-
-  useEffect(() => {
     if (!isDrawing) {
       props.onChange?.(lines);
     }
-  }, [isDrawing, lines, props.onChange]);
-
-  useEffect(() => {
-    if (isDrawing) {
-      window.addEventListener("touchstart", handleScrolling, { 'passive': false });
-    }
-    else {
-      window.removeEventListener("touchstart", handleScrolling);
-    }
   }, [isDrawing]);
+
+  // useEffect(() => {
+  //   if (isDrawing) {
+  //     window.addEventListener("touchstart", handleScrolling, { 'passive': false });
+  //   }
+  //   else {
+  //     window.removeEventListener("touchstart", handleScrolling);
+  //   }
+  // }, [isDrawing]);
 
   function handlePointerDown(
     pointerEvent: React.PointerEvent<HTMLDivElement>
@@ -87,6 +79,9 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
     if (pointerEvent.button !== 0 || props.readonly) {
       return;
     }
+
+    pointerEvent.preventDefault();
+    pointerEvent.stopPropagation();
 
     const newPoint = relativeCoordinatesForEvent(pointerEvent);
     if (newPoint) {
@@ -119,8 +114,19 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
     }
   }
 
-  function handlePointerUp() {
-    setDrawing(false);
+  function handlePointerUp(
+    pointerEvent: React.PointerEvent<HTMLDivElement>
+  ) {
+    if (pointerEvent.pointerType == "mouse") {
+      setDrawing(false);
+    }
+  }
+
+  function handleBlur(
+    blurEvent: React.FocusEvent<HTMLDivElement>
+  ) {
+    if (isDrawing)
+      setDrawing(false);
   }
 
   function relativeCoordinatesForEvent(
@@ -149,11 +155,13 @@ export const DrawArea = React.forwardRef<IHandles, IProps>((props, ref) => {
         width: "100%",
         height: "100%",
         cursor: props.readonly ? "inherit" : "crosshair",
+        touchAction: isDrawing ? "none" : "auto",
       })}
       ref={$container}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
+      onBlur={handleBlur}
     >
       {lines.length === 0 ? (
         <Fade in>


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- **feat** Switched out the mouse events for pointer event, allowing for touch controls on the drawable area.

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

When using the app on a touch screen device, instead of drawing on the draw area, it scrolls. This change allows for a more intuitive reaction on touch screen devices.

## 🔒Checklist

- Tested with a touch screen laptop and personal Android device. Seems to behave as I expect it should. 

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
