### PR TITLE
feat: v3.1.0 (upsert characters for everyone during play session)

### DIFF
--- a/lib/contexts/CharactersContext/CharactersContext.tsx
+++ b/lib/contexts/CharactersContext/CharactersContext.tsx
@@ -100,6 +100,20 @@ export function useCharacters(props?: { localStorage: Storage }) {
     return character;
   }
 
+  function updateIfExists(character: ICharacter | undefined) {
+    if (!character) {
+      return;
+    }
+    setCharacters((draft: Array<ICharacter>) => {
+      return draft.map((c) => {
+        if (c.id === character.id) {
+          return character;
+        }
+        return c;
+      });
+    });
+  }
+
   function remove(id: string | undefined) {
     setCharacters((draft: Array<ICharacter>) => {
       return draft.filter((c) => c.id !== id);
@@ -117,6 +131,7 @@ export function useCharacters(props?: { localStorage: Storage }) {
       closeManager,
       add,
       upsert,
+      updateIfExists,
       remove,
     },
   };

--- a/lib/contexts/CharactersContext/__tests__/CharactersContext.test.tsx
+++ b/lib/contexts/CharactersContext/__tests__/CharactersContext.test.tsx
@@ -179,7 +179,7 @@ describe("useCharacters", () => {
         newCharacter = result.current.actions.upsert({
           ...newCharacter,
           name: "UPDATED NAME",
-        } as any);
+        } as ICharacter);
       });
 
       let playingCharacter: ICharacter | undefined = undefined;
@@ -187,7 +187,7 @@ describe("useCharacters", () => {
         // WHEN I save a character I'm already playing
         playingCharacter = result.current.actions.upsert({
           id: "an id from a live session",
-        } as any);
+        } as ICharacter);
       });
       // THEN the new character has been added and is properly sorted
       expect(result.current.state.characters[0]).toEqual(
@@ -226,6 +226,53 @@ describe("useCharacters", () => {
           id: newCharacter!.id,
           lastUpdated: newCharacter!.lastUpdated,
           name: "UPDATED NAME",
+        })
+      );
+
+      act(() => {
+        // WHEN I update an undefined character
+        result.current.actions.updateIfExists(undefined as any);
+      });
+      // THEN nothing happens
+      expect(result.current.state.characters[0]).toEqual(
+        expect.objectContaining({
+          id: newCharacter!.id,
+          lastUpdated: newCharacter!.lastUpdated,
+          name: "UPDATED NAME",
+        })
+      );
+
+      act(() => {
+        // WHEN I update a character that is not in the DB
+        result.current.actions.updateIfExists({
+          id: "id-that-is-not-in-the-db",
+          name: "A NEW NAME",
+        } as ICharacter);
+      });
+      // THEN nothing happens
+      expect(result.current.state.characters.length).toEqual(1);
+      expect(result.current.state.characters[0]).toEqual(
+        expect.objectContaining({
+          id: newCharacter!.id,
+          lastUpdated: newCharacter!.lastUpdated,
+          name: "UPDATED NAME",
+        })
+      );
+
+      act(() => {
+        // WHEN I update a character that is in the DB
+        result.current.actions.updateIfExists({
+          ...newCharacter,
+          name: "A NEW NAME",
+        } as ICharacter);
+      });
+      // THEN the character is updated
+      expect(result.current.state.characters.length).toEqual(1);
+      expect(result.current.state.characters[0]).toEqual(
+        expect.objectContaining({
+          id: newCharacter!.id,
+          lastUpdated: newCharacter!.lastUpdated,
+          name: "A NEW NAME",
         })
       );
 

--- a/lib/hooks/useScene/__tests__/useScene.test.ts
+++ b/lib/hooks/useScene/__tests__/useScene.test.ts
@@ -702,12 +702,16 @@ fdescribe("useScene", () => {
     // WHEN safeSet
     act(() => {
       result.current.useScene.actions.safeSetScene(({
-        players: [{}],
+        players: [{ character: {} }, { character: {} }],
       } as unknown) as any);
     });
     // THEN
-    expect(result.current.useScene.state.scene).toEqual({ players: [{}] });
-    // expect(result.current.useCharacters.actions.upsert).toHaveBeenCalled();
+    expect(result.current.useScene.state.scene).toEqual({
+      players: [{ character: {} }, { character: {} }],
+    });
+    expect(
+      result.current.useCharacters.actions.updateIfExists
+    ).toHaveBeenCalledTimes(2);
   });
   describe("o", () => {
     const userId = "111";
@@ -750,23 +754,25 @@ fdescribe("useScene", () => {
 });
 
 function mockUseCharacters() {
+  const result = {
+    state: {
+      characters: [],
+      mode: ManagerMode.Close,
+      managerCallback: undefined,
+    },
+    actions: {
+      add: jest.fn(),
+      upsert: jest.fn(),
+      updateIfExists: jest.fn(),
+      remove: jest.fn(),
+      select: jest.fn(),
+      clearSelected: jest.fn(),
+      closeManager: jest.fn(),
+      openManager: jest.fn(),
+    },
+  } as ReturnType<typeof useCharacters>;
   return () => {
-    return {
-      state: {
-        characters: [],
-        mode: ManagerMode.Close,
-        managerCallback: undefined,
-      },
-      actions: {
-        add: jest.fn(),
-        upsert: jest.fn(),
-        remove: jest.fn(),
-        select: jest.fn(),
-        clearSelected: jest.fn(),
-        closeManager: jest.fn(),
-        openManager: jest.fn(),
-      },
-    } as ReturnType<typeof useCharacters>;
+    return result;
   };
 }
 

--- a/lib/hooks/useScene/useScene.ts
+++ b/lib/hooks/useScene/useScene.ts
@@ -111,7 +111,7 @@ export function useScene(props: IProps) {
     if (newScene) {
       setScene(newScene);
       newScene.players.forEach((p) => {
-        charactersManager.actions.upsert(p.character);
+        charactersManager.actions.updateIfExists(p.character);
       });
     }
   }
@@ -464,7 +464,7 @@ export function useScene(props: IProps) {
         });
       })
     );
-    charactersManager.actions.upsert(character);
+    charactersManager.actions.updateIfExists(character);
   }
 
   function updatePlayerFatePoints(id: string, fatePoints: number) {


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: saving characters only if they exists

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

This PR fixes a pretty major issue I encountered yesterday while playing with the latest version with a couple of friends.

The issue is that when a player saves their character, the scene was calling a function to `update or insert` the character while it should have been using an `update only if exists` logic.

Because of this, it would cause everyone to have access to a copy of everyone's character. 
I think it's also part of the reason why we all ended up with 100 copies of someone's character.. (but I'm not 100% sure)

**Steps to reproduce**

* open two browsers
* create a session in the first browser
* create a character in the second browser
* copy the game link of the first browser
* join the session from the second browser with the created character
* from the second browser, open the character sheet, make a random change and save

**Expected behavior**
* the player should have their character sheet updated
* the GM should not have a copy of the character in its database

**Current behavior**
* Both the GM and the players have a version of the character

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->

![image](https://user-images.githubusercontent.com/6224111/91312042-c62f2f80-e781-11ea-9570-0bc8e7ed58e8.png)

