### PR TITLE
fix: v.3.3.7 (scene dirty state, useDrawing.setpointerCapture exception, MagicGrid check isMounted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.3.0-6 (Nov 10, 2020 - Dec 7 2020) - Group Scenes or Character Sheets, Roll with modifier and Russian Localizations
+## 3.3.0-7 (Nov 10, 2020 - Dec 7 2020) - Group Scenes or Character Sheets, Roll with modifier and Russian Localizations
 
 - feat: Group Scenes or Character sheets by campaigns
 - feat: Click on a skill to roll + skill modifier
@@ -11,6 +11,8 @@
 - fix: share draw area controls between fullscreen and normal mode [#147](https://github.com/fariapp/fari/issues/147)
 - fix: character sheet synchronisation [#151](https://github.com/fariapp/fari/issues/151)
 
+**3.3.6**
+
 - chore: bump all dependencies
 - fix: emotion package import
 - feat: performance boost removing about page markdown (saves 1s on load time)
@@ -18,6 +20,11 @@
 - fix: #160 encoding issues when transferring player names with emojis like 🐺
 - fix: #163 map not updating for players
 - fix: #119 more robust character sync
+
+**3.3.7**
+
+- fix: disable setAspectDrawArea to stop default isDirty on scene load
+- fix: add try-catch on useDrawing setPointerCapture for unsupported browsers
 
 ## 3.2.0 (Oct 20, 2020) - New Drawing Area, Brazian Portuguse translations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - fix: disable setAspectDrawArea to stop default isDirty on scene load
 - fix: add try-catch on useDrawing setPointerCapture for unsupported browsers
+- fix: only reposition index card if component is mounted
 
 ## 3.2.0 (Oct 20, 2020) - New Drawing Area, Brazian Portuguse translations
 

--- a/lib/components/DrawArea/hooks/useDrawing.ts
+++ b/lib/components/DrawArea/hooks/useDrawing.ts
@@ -119,7 +119,12 @@ export function useDrawing(props: {
 
     pointerEvent.preventDefault();
     pointerEvent.stopPropagation();
-    $container.current?.setPointerCapture(pointerEvent.pointerId);
+
+    try {
+      $container.current?.setPointerCapture(pointerEvent.pointerId);
+    } catch (error) {
+      // ignore
+    }
 
     const newPoint = relativeCoordinatesForEvent(pointerEvent);
     if (!newPoint) {
@@ -238,7 +243,12 @@ export function useDrawing(props: {
 
     if (validPointerTypes.includes(pointerEvent.pointerType)) {
       setDrawing(false);
-      $container.current?.releasePointerCapture(pointerEvent.pointerId);
+
+      try {
+        $container.current?.releasePointerCapture(pointerEvent.pointerId);
+      } catch (error) {
+        // ignore
+      }
     }
   }
 

--- a/lib/components/IndexCard/IndexCard.tsx
+++ b/lib/components/IndexCard/IndexCard.tsx
@@ -90,6 +90,9 @@ export const IndexCard: React.FC<
             <DrawArea
               objects={aspect!.drawAreaObjects}
               onChange={(objects) => {
+                if (!aspect.hasDrawArea) {
+                  return;
+                }
                 props.sceneManager.actions.setAspectDrawAreaObjects(
                   props.aspectId,
                   objects

--- a/lib/components/MagicGridContainer/MagicGridContainer.tsx
+++ b/lib/components/MagicGridContainer/MagicGridContainer.tsx
@@ -1,5 +1,6 @@
 import MagicGrid from "magic-grid";
 import React, { useEffect, useRef } from "react";
+import { useMounted } from "../../hooks/useMounted/useMounted";
 
 const DefaultMagicGridGutter = 0;
 const MagicGridUpdateDebounceMS = 200;
@@ -9,6 +10,7 @@ export const MagicGridContainer: React.FC<{
   gutterPx?: number;
   deps: Array<any>;
 }> = (props) => {
+  const isMounted = useMounted();
   const $gridContainer = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -25,7 +27,9 @@ export const MagicGridContainer: React.FC<{
       magicGrid.current.positionItems();
 
       setTimeout(() => {
-        magicGrid.current?.positionItems();
+        if (isMounted) {
+          magicGrid.current?.positionItems();
+        }
       });
 
       window.addEventListener("resize", resize);

--- a/lib/hooks/useMounted/useMounted.ts
+++ b/lib/hooks/useMounted/useMounted.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useMounted() {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    return () => setIsMounted(false);
+  }, []);
+
+  return isMounted;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fari",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "description": "Fari is the best Fate RPG companion application. License: AGPL-3.0-or-later",
   "author": "René-Pier Deshaies-Gélinas",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: disable setAspectDrawArea to stop default isDirty on scene load
- fix: add try-catch on useDrawing setPointerCapture for unsupported browsers
- fix: only reposition index card if component is mounted

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

This PR fixes a couple of errors I've seen hapenning on Sentry

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
