### PR TITLE
feat:Index card "has played" icon now displays a tooltip

### DIFF
--- a/lib/components/IndexCard/IndexCard.tsx
+++ b/lib/components/IndexCard/IndexCard.tsx
@@ -395,23 +395,33 @@ export const IndexCard: React.FC<
         </Grid>
         <Grid item>
           {shouldRenderPlayedDuringTurnIcon && (
-            <IconButton
-              data-cy={`${props["data-cy"]}.initiative`}
-              onClick={() => {
-                props.sceneManager.actions.updateAspectPlayerDuringTurn(
-                  props.aspectId,
-                  !aspect.playedDuringTurn
-                );
-              }}
-              disabled={props.readonly}
-              size="small"
+            <Tooltip
+                title={
+                aspect.playedDuringTurn
+                    ? t("player-row.played")
+                    : t("player-row.not-played")
+                }
             >
-              {aspect.playedDuringTurn ? (
-                <DirectionsRunIcon htmlColor={playedDuringTurnColor} />
-              ) : (
-                <EmojiPeopleIcon htmlColor={playedDuringTurnColor} />
-              )}
-            </IconButton>
+              <span>
+                <IconButton
+                  data-cy={`${props["data-cy"]}.initiative`}
+                  onClick={() => {
+                    props.sceneManager.actions.updateAspectPlayerDuringTurn(
+                      props.aspectId,
+                      !aspect.playedDuringTurn
+                    );
+                  }}
+                  disabled={props.readonly}
+                  size="small"
+                >
+                  {aspect.playedDuringTurn ? (
+                    <DirectionsRunIcon htmlColor={playedDuringTurnColor} />
+                  ) : (
+                    <EmojiPeopleIcon htmlColor={playedDuringTurnColor} />
+                  )}
+                </IconButton>
+              </span>
+            </Tooltip>
           )}
         </Grid>
       </Grid>


### PR DESCRIPTION

## ✅ Changes

- feat: index card "has played" icon now has a tool tip, matching the similar button in player row

## 🌄 Context

While trying out fari I found the has played button on the index cards and did not understand what it meant from the icon. I later saw the same button in player row and learned the meaning from the tool tip.

## 🔒Checklist

- I verified that the tool tip appeared by running the npc index card in storybook. I checked both has and has not played states
- I also verified in app on the scenes page for npcs and bad guys

## 💅 Examples