### PR TITLE
feat: v4.0.7 (clicking roll button when dice menu is closed rolls latest rolled commands instead of new ones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - feat: enable customizing dice pools without toggling the advanced mode using Right Clicks!
 - feat: give the ability to use Skills/Pools dice commands and add other dice commands using the dice menu.
 - feat: new Player component UI
+- fix: clicking on the roll button when the dice menu is closed rolls the latest rolled commands instead of the selected ones
 
 # v3.7 Fari Wiki, Success With Style, Image Preview, Dice Menu
 

--- a/lib/components/DiceFab/DiceFab.tsx
+++ b/lib/components/DiceFab/DiceFab.tsx
@@ -71,12 +71,6 @@ export const DiceFab: React.FC<IProps> = (props) => {
     }
   }
 
-  function handleReRoll() {
-    const result = diceManager.actions.reroll();
-    props.onRoll?.(result);
-    handleMenuClose();
-  }
-
   function handleRoll() {
     const result = diceManager.actions.rollCommandGroups();
 
@@ -109,11 +103,7 @@ export const DiceFab: React.FC<IProps> = (props) => {
               if (hasPool) {
                 handleRollPool();
               } else {
-                if (open) {
-                  handleRoll();
-                } else {
-                  handleReRoll();
-                }
+                handleRoll();
               }
             }}
           />

--- a/lib/components/Scene/Scene.tsx
+++ b/lib/components/Scene/Scene.tsx
@@ -579,7 +579,7 @@ export const Scene: React.FC<IProps> = (props) => {
                   onDiceRoll={() => {
                     handleSetPlayerRoll(
                       player.id,
-                      diceManager.actions.reroll()
+                      diceManager.actions.rollCommandGroups()
                     );
                   }}
                   onPlayedInTurnOrderChange={(playedInTurnOrder) => {

--- a/lib/contexts/DiceContext/DiceContext.tsx
+++ b/lib/contexts/DiceContext/DiceContext.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   AllDiceCommandGroups,
   Dice,
   IDiceCommandGroup,
-  IDiceCommandGroupId,
   IDiceCommandOption,
   IRollDiceOptions,
   RollType,
@@ -12,7 +11,6 @@ import {
   IDicePool,
   IDicePoolElement,
 } from "../../routes/Character/components/CharacterDialog/components/blocks/BlockDicePool";
-import { DiceCommandGroup } from "../../routes/Character/components/CharacterDialog/domains/DiceCommandGroup/DiceCommandGroup";
 
 export type IDiceManager = ReturnType<typeof useDice>;
 
@@ -26,18 +24,18 @@ export const DefaultDiceCommandOptions: Array<IDiceCommandOption> = [
 ];
 
 export function useDice() {
-  const [latestCommandOptions, setLatestCommandOptions] = useState<
-    Array<IDiceCommandOption>
-  >(DefaultDiceCommandOptions);
   const [options, setOptions] = useState<IRollDiceOptions>({
     listResults: false,
   });
 
   const [pool, setPool] = useState<IDicePool>([]);
   const [playerId, setPlayerId] = useState<string>();
-  const [commandGroups, setCommandGroups] = useState<Array<IDiceCommandGroup>>(
-    []
-  );
+  const [commandGroups, setCommandGroups] = useState<Array<IDiceCommandGroup>>([
+    AllDiceCommandGroups["4dF"],
+  ]);
+  const [commandGroupsBeforePool, setCommandGroupsBeforePool] = useState<
+    Array<IDiceCommandGroup>
+  >([]);
   const poolCommandGroups = useMemo(() => {
     const poolCommandOptionList = pool.flatMap((dicePoolElement) => {
       return dicePoolElement.commandOptionList;
@@ -57,27 +55,10 @@ export function useDice() {
   }, [pool]);
   const allCommandGroups = [...commandGroups, ...poolCommandGroups];
 
-  const latestCommandGroupIds: Array<IDiceCommandGroupId> = useMemo(() => {
-    const result = latestCommandOptions
-      .map((c) =>
-        c.type === RollType.DiceCommand ? c.commandGroupId : undefined
-      )
-      .filter((c) => !!c) as Array<IDiceCommandGroupId>;
-    return result;
-  }, [latestCommandOptions]);
-
-  useEffect(() => {
-    const newCommandGroups = latestCommandGroupIds.map((commandGroupId) =>
-      DiceCommandGroup.getCommandGroupById(commandGroupId)
-    );
-    setCommandGroups(newCommandGroups);
-  }, [latestCommandGroupIds]);
-
   function reset() {
-    setLatestCommandOptions(DefaultDiceCommandOptions);
+    setCommandGroups([]);
   }
   function clear() {
-    setLatestCommandOptions([]);
     clearPool();
   }
 
@@ -85,7 +66,6 @@ export function useDice() {
     newCommands: Array<IDiceCommandOption>,
     optionsForRoll: IRollDiceOptions = options
   ) {
-    setLatestCommandOptions(newCommands);
     setOptions(optionsForRoll);
     const result = Dice.rollCommandOptionList(newCommands, optionsForRoll);
     return result;
@@ -104,22 +84,10 @@ export function useDice() {
     return roll(commandOptions, optionsForRoll);
   }
 
-  /**
-   * Reroll the latest commands
-   * @param options if empty, uses the latest options
-   */
-  function reroll(optionsForRoll: IRollDiceOptions = options) {
-    const result = Dice.rollCommandOptionList(
-      latestCommandOptions,
-      optionsForRoll
-    );
-    return result;
-  }
-
   function addOrRemovePoolElement(element: IDicePoolElement) {
     const isFirstPoolElement = pool.length === 0;
     if (isFirstPoolElement) {
-      setCommandGroups([]);
+      preparePool();
     }
     setPool((draft) => {
       const ids = draft.map((element) => element.blockId);
@@ -132,9 +100,9 @@ export function useDice() {
     });
   }
 
-  function clearPool() {
-    setPool([]);
-    setPlayerId(undefined);
+  function preparePool() {
+    setCommandGroupsBeforePool(commandGroups);
+    setCommandGroups([]);
   }
 
   function getPoolResult() {
@@ -158,9 +126,15 @@ export function useDice() {
     return { result, playerId: latestPlayerId };
   }
 
+  function clearPool() {
+    setPool([]);
+    setCommandGroups(commandGroupsBeforePool);
+    setCommandGroupsBeforePool([]);
+    setPlayerId(undefined);
+  }
+
   return {
     state: {
-      commandNames: latestCommandGroupIds,
       options: options,
       commandGroups: allCommandGroups,
       pool,
@@ -168,7 +142,6 @@ export function useDice() {
     actions: {
       roll,
       rollCommandGroups,
-      reroll,
       reset,
       setOptions: setOptions,
       setCommandGroups,

--- a/lib/routes/Dice/DiceRoute.tsx
+++ b/lib/routes/Dice/DiceRoute.tsx
@@ -31,7 +31,9 @@ export function DiceRoute(props: { pool: boolean }) {
     function onLoad() {
       if (!props.pool) {
         logger.info("Route:Dice");
-        setRollResult(diceManager.actions.reroll({ listResults: props.pool }));
+        setRollResult(
+          diceManager.actions.rollCommandGroups({ listResults: props.pool })
+        );
       } else {
         logger.info("Route:DicePool");
       }
@@ -48,7 +50,7 @@ export function DiceRoute(props: { pool: boolean }) {
   };
 
   const handleRoll = () => {
-    setRollResult(diceManager.actions.reroll());
+    setRollResult(diceManager.actions.rollCommandGroups());
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fari",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Fari is the best Fate RPG companion application. License: AGPL-3.0-or-later",
   "author": "René-Pier Deshaies-Gélinas",
   "license": "AGPL-3.0",


### PR DESCRIPTION

## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: clicking the roll button when the dice menu is closed rerolls the latest rolled commands instead of the selected ones

> Not sure if this counts as a bug, but if I click out of the dice roller before rolling, and then roll, the roller will keep the previous dice input. This includes repeating previous skill rolls. You must roll while the dice menu is up in order to change the rolled dice. - Tolamaker

https://discord.com/channels/797926344893005875/798217992848146463/836041943196237894

## ⛰️  Context

When the dice menu is opened, everytime a user selects or deselects a dice command group, it saves it in the global context.

When a user rolled a set a dice commands, it saved that info as well so that you could "reroll" them but its not really a behavior we want anymore since dice commands arent cleared after a dice roll (like it was a couple of weeks ago)

Though changing the behavior makes managing dice pools (selecting dice commands from character sheets) tricky since clicking a pool block used to remove the entire list of currently selected commands. So to fix this, I made sure that when a dice pool element is added and its the first one, I save the current selected dice commands and whent the pool is rolled, I reset the commands like they were before the pool was created.